### PR TITLE
Fix peerDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "url": "https://github.com/jossmac/react-node-resolver/issues"
   },
   "homepage": "https://github.com/jossmac/react-node-resolver#readme",
-  "peer-dependencies": {
+  "peerDependencies": {
     "react": "^15.0 || ^16.0",
     "react-dom": "^15.0 || ^16.0"
   },


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/646098/50254872-d4249d00-0443-11e9-8456-6bdd8c6d84ad.png)

When I install this package, I don't get warned about the peerDependencies required

After this change:
![image](https://user-images.githubusercontent.com/646098/50254932-10f09400-0444-11e9-8adf-e08a40d83743.png)
